### PR TITLE
Fix README typo and Categorize terminal log

### DIFF
--- a/GPTBot.py
+++ b/GPTBot.py
@@ -32,7 +32,7 @@ class aclient(discord.Client):
             await tree.sync()
             self.synced = True
 
-        print('Logged in as:')
+        print('\u001b[43;1m[INFO]\u001b[0m Logged in as:')
         print(f'{self.user.name}, {self.user.id}')
         print('Created by Joeyy#4628. The most up-to-date code can be found on github: https://github.com/Joeya1ds/Discord-GPT3-Bot')
         print('--------------------------------------------------------------------------------------------------------------------')
@@ -63,7 +63,7 @@ async def ask(interaction: discord.Interaction, prompt: str):
 
         await asyncio.sleep(3)
         await interaction.followup.send('I cannot respond to what you have said, it has been flagged by the Moderation API.')
-        print(f'User with ID: {user_id} has had a prompt flagged by the Moderation API. Consider checking logs.')
+        print(f'\u001b[41;1m[WARN]\u001b[0m User with ID: {user_id} has had a prompt flagged by the Moderation API. Consider checking logs.')
         
         return
 

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ Before running the bot, you will need to configure **[config.json]('./config.jso
 To run the bot, use the following command:
 
 ```sh
-python bot.py
+cd /path/to/Discord-GPT3-Bot
+python GPTBot.py
 ```
 
 This will start the bot and allow it to listen for commands and generate responses.


### PR DESCRIPTION
I fixed a typo in the "Running the bot section" by changing the run command and I also categorize the terminal log and also add color to it

here's the example:
<img width="723" alt="Screen Shot 2565-12-22 at 12 19 04" src="https://user-images.githubusercontent.com/46487993/209062790-556238d5-8212-4159-8610-bd55e4dc5038.png">
